### PR TITLE
fix: enable automation to create quay repos

### DIFF
--- a/.github/scripts/tkn_push_bundles.sh
+++ b/.github/scripts/tkn_push_bundles.sh
@@ -39,29 +39,6 @@ do
 
   API_HTTP="https://${IMAGE_REGISTRY}/api/v1"
 
-  # Test if the repo does not exist at {registry}/{namespace}.
-  if ! grep "${2}-${3}" < <(
-    curl \
-      --silent \
-      --request GET "${API_HTTP}/repository?namespace=${IMAGE_NAMESPACE}" \
-      --header "Authorization: Bearer ${QUAY_API_TOKEN}" | \
-    jq '.repositories[].name'
-  )
-  then
-    # Repo does not exist, so first create the repo.
-    printf -v new_repo_string -- \
-      '{"namespace": "%s", "repository": "%s", "description": "%s", "visibility": "%s", "repo_kind": "%s"}' \
-      "$IMAGE_NAMESPACE" "${2}-${3}" "${2}-${3}" "public" "image"
-
-    printf 'Creating new repo: %s\n' "$image_string"
-    curl \
-      --silent \
-      --request POST "${API_HTTP}/repository?namespace=${IMAGE_NAMESPACE}" \
-      --header "Authorization: Bearer ${QUAY_API_TOKEN}" \
-      --header 'Content-Type: application/json' \
-      --data "$new_repo_string"
-  fi
-
   # Tag with version dir string
   printf 'Pushing image to repo: %s:%s\n' "$image_string" "${4}"
   tkn bundle push -f "${VERSION_DIR}/${3}.yaml" "${image_string}:${4}"

--- a/.github/workflows/tekton_bundle_push.yaml
+++ b/.github/workflows/tekton_bundle_push.yaml
@@ -13,7 +13,6 @@ env:
   IMAGE_NAMESPACE: hacbs-release
   REGISTRY_USER: ${{ secrets.QUAY_ROBOT_USER }}
   REGISTRY_PASSWORD: ${{ secrets.QUAY_ROBOT_TOKEN }}
-  API_TOKEN: ${{ secrets.QUAY_API_TOKEN }}
 jobs:
   run-pipeline:
     name: Tekton Bundle
@@ -46,4 +45,3 @@ jobs:
           GITHUB_REFNAME: ${{ github.ref_name }}
           IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
           IMAGE_NAMESPACE: ${{ env.IMAGE_NAMESPACE }}
-          QUAY_API_TOKEN: ${{ env.API_TOKEN }}


### PR DESCRIPTION
We have some curl commands to check if a repo exists, and if it does not, to create it. tkn bundle push creates a new repo if it does not exist for free, so I am not sure why the curl commands are in there. This commit removes them.

Signed-off-by: Johnny Bieren <jbieren@redhat.com>