### PR TITLE
chore(RHTAPREL-730): update taskGitRevision to staging

### DIFF
--- a/pipelines/deploy-release/README.md
+++ b/pipelines/deploy-release/README.md
@@ -14,7 +14,7 @@ Tekton pipeline to verify Snapshot prior to Deployment
 | enterpriseContractPublicKey | Public key to use for validation by the enterprise contract | Yes | k8s://openshift-pipelines/public-key |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | development |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | staging |
 
 ## Changes in 0.12.0
 - taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks

--- a/pipelines/deploy-release/deploy-release.yaml
+++ b/pipelines/deploy-release/deploy-release.yaml
@@ -42,7 +42,7 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: development
+      default: staging
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline

--- a/pipelines/deploy-release/samples/sample_release_PipelineRun.yaml
+++ b/pipelines/deploy-release/samples/sample_release_PipelineRun.yaml
@@ -23,6 +23,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-catalog.git
       - name: revision
-        value: development
+        value: staging
       - name: pathInRepo
         value: pipelines/deploy-release/deploy-release.yaml

--- a/pipelines/deploy-release/tests/run.yaml
+++ b/pipelines/deploy-release/tests/run.yaml
@@ -23,6 +23,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-catalog.git
       - name: revision
-        value: development
+        value: staging
       - name: pathInRepo
         value: pipelines/deploy-release/deploy-release.yaml

--- a/pipelines/e2e/README.md
+++ b/pipelines/e2e/README.md
@@ -16,7 +16,7 @@ affected by RHTAP services or which results could affect the RHTAP workflow.
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | development |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | staging |
 
 ## Changes in 0.3.0
 * taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks

--- a/pipelines/e2e/e2e.yaml
+++ b/pipelines/e2e/e2e.yaml
@@ -43,7 +43,7 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: development
+      default: staging
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline

--- a/pipelines/e2e/samples/e2e-pipelinerun.yaml
+++ b/pipelines/e2e/samples/e2e-pipelinerun.yaml
@@ -23,6 +23,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-catalog.git
       - name: revision
-        value: development
+        value: staging
       - name: pathInRepo
         value: pipelines/e2e/e2e.yaml

--- a/pipelines/e2e/tests/run.yaml
+++ b/pipelines/e2e/tests/run.yaml
@@ -23,6 +23,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-catalog.git
       - name: revision
-        value: development
+        value: staging
       - name: pathInRepo
         value: pipelines/e2e/e2e.yaml

--- a/pipelines/fbc-release/README.md
+++ b/pipelines/fbc-release/README.md
@@ -15,7 +15,7 @@ Tekton release pipeline to interact with FBC Pipeline
 | verify_ec_task_bundle           | The location of the bundle containing the verify-enterprise-contract task                                | No        | -                                                               |
 | postCleanUp                     | Cleans up workspace after finishing executing the pipeline                                               | Yes       | true                                                            |
 | taskGitUrl                      | The url to the git repo where the release-service-catalog tasks to be used are stored                    | Yes       | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | Yes       | development                                                            |
+| taskGitRevision                 | The revision in the taskGitUrl repo to be used                                                           | Yes       | staging                                                            |
 
 ### Changes in 1.6.0
 - modify the task `publish-index-image` to accept the new parameter `buildTimestamp` used

--- a/pipelines/fbc-release/fbc-release.yaml
+++ b/pipelines/fbc-release/fbc-release.yaml
@@ -42,7 +42,7 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: development
+      default: staging
     - name: postCleanUp
       type: string
       description: Cleans up workspace after finishing executing the pipeline

--- a/pipelines/fbc-release/samples/sample_release_PipelineRun.yaml
+++ b/pipelines/fbc-release/samples/sample_release_PipelineRun.yaml
@@ -27,6 +27,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-catalog.git
       - name: revision
-        value: development
+        value: staging
       - name: pathInRepo
         value: pipelines/fbc-release/fbc-release.yaml

--- a/pipelines/fbc-release/tests/run.yaml
+++ b/pipelines/fbc-release/tests/run.yaml
@@ -27,6 +27,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-catalog.git
       - name: revision
-        value: development
+        value: staging
       - name: pathInRepo
         value: pipelines/fbc-release/fbc-release.yaml

--- a/pipelines/push-to-external-registry/README.md
+++ b/pipelines/push-to-external-registry/README.md
@@ -15,7 +15,7 @@ Tekton pipeline to release Snapshots to an external registry.
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | development |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | staging |
 
 ## Changes in 2.0.0
 - Pipeline renamed from `release` to `push-to-external-registry`

--- a/pipelines/push-to-external-registry/push-to-external-registry.yaml
+++ b/pipelines/push-to-external-registry/push-to-external-registry.yaml
@@ -46,7 +46,7 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: development
+      default: staging
   workspaces:
     - name: release-workspace
   tasks:

--- a/pipelines/push-to-external-registry/samples/sample_release_PipelineRun.yaml
+++ b/pipelines/push-to-external-registry/samples/sample_release_PipelineRun.yaml
@@ -25,6 +25,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-catalog.git
       - name: revision
-        value: development
+        value: staging
       - name: pathInRepo
         value: pipelines/push-to-external-registry/push-to-external-registry.yaml

--- a/pipelines/push-to-external-registry/tests/run.yaml
+++ b/pipelines/push-to-external-registry/tests/run.yaml
@@ -25,6 +25,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-catalog.git
       - name: revision
-        value: development
+        value: staging
       - name: pathInRepo
         value: pipelines/push-to-external-registry/push-to-external-registry.yaml

--- a/pipelines/release-to-github/README.md
+++ b/pipelines/release-to-github/README.md
@@ -15,4 +15,4 @@ Tekton release pipeline to release binaries extracted from the image built with 
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | development |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | staging |

--- a/pipelines/release-to-github/release-to-github.yaml
+++ b/pipelines/release-to-github/release-to-github.yaml
@@ -47,7 +47,7 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: development
+      default: staging
   workspaces:
     - name: release-workspace
   tasks:

--- a/pipelines/release-to-github/samples/release-to-github_PipelineRun.yaml
+++ b/pipelines/release-to-github/samples/release-to-github_PipelineRun.yaml
@@ -25,6 +25,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-catalog.git
       - name: revision
-        value: development
+        value: staging
       - name: pathInRepo
         value: pipelines/release-to-github/release-to-github.yaml

--- a/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
+++ b/pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml
@@ -46,7 +46,7 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: development
+      default: staging
   workspaces:
     - name: release-workspace
   tasks:

--- a/pipelines/rh-push-to-external-registry/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/pipelines/rh-push-to-external-registry/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -25,6 +25,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-catalog.git
       - name: revision
-        value: development
+        value: staging
       - name: pathInRepo
         value: pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml

--- a/pipelines/rh-push-to-external-registry/tests/run.yaml
+++ b/pipelines/rh-push-to-external-registry/tests/run.yaml
@@ -25,6 +25,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-catalog.git
       - name: revision
-        value: development
+        value: staging
       - name: pathInRepo
         value: pipelines/rh-push-to-external-registry/rh-push-to-external-registry.yaml

--- a/pipelines/rh-push-to-registry-redhat-io/README.md
+++ b/pipelines/rh-push-to-registry-redhat-io/README.md
@@ -15,7 +15,7 @@ Tekton pipeline to release content to registry.redhat.io registry.
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | development |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | staging |
 
 ## Changes in 1.7.0
 * taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks

--- a/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml
@@ -46,7 +46,7 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: development
+      default: staging
   workspaces:
     - name: release-workspace
   tasks:

--- a/pipelines/rh-push-to-registry-redhat-io/samples/sample_rh-push-to-registry-redhat-io_PipelineRun.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/samples/sample_rh-push-to-registry-redhat-io_PipelineRun.yaml
@@ -25,6 +25,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-catalog.git
       - name: revision
-        value: development
+        value: staging
       - name: pathInRepo
         value: pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml

--- a/pipelines/rh-push-to-registry-redhat-io/tests/run.yaml
+++ b/pipelines/rh-push-to-registry-redhat-io/tests/run.yaml
@@ -25,6 +25,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-catalog.git
       - name: revision
-        value: development
+        value: staging
       - name: pathInRepo
         value: pipelines/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml

--- a/pipelines/rhtap-service-push/README.md
+++ b/pipelines/rhtap-service-push/README.md
@@ -17,7 +17,7 @@
 | postCleanUp | Cleans up workspace after finishing executing the pipeline | Yes | true |
 | verify_ec_task_bundle | The location of the bundle containing the verify-enterprise-contract task | No | - |
 | taskGitUrl | The url to the git repo where the release-service-catalog tasks to be used are stored | Yes | https://github.com/redhat-appstudio/release-service-catalog.git |
-| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | development |
+| taskGitRevision | The revision in the taskGitUrl repo to be used | Yes | staging |
 
 ## Changes in 1.3.0
 - taskGitUrl parameter is added. It is used to provide the git repo for the release-service-catalog tasks

--- a/pipelines/rhtap-service-push/rhtap-service-push.yaml
+++ b/pipelines/rhtap-service-push/rhtap-service-push.yaml
@@ -46,7 +46,7 @@ spec:
     - name: taskGitRevision
       type: string
       description: The revision in the taskGitUrl repo to be used
-      default: development
+      default: staging
   workspaces:
     - name: release-workspace
   tasks:

--- a/pipelines/rhtap-service-push/samples/sample_push-to-external-registry_PipelineRun.yaml
+++ b/pipelines/rhtap-service-push/samples/sample_push-to-external-registry_PipelineRun.yaml
@@ -25,6 +25,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-catalog.git
       - name: revision
-        value: development
+        value: staging
       - name: pathInRepo
         value: pipelines/rhtap-service-push/rhtap-service-push.yaml

--- a/pipelines/rhtap-service-push/tests/run.yaml
+++ b/pipelines/rhtap-service-push/tests/run.yaml
@@ -25,6 +25,6 @@ spec:
       - name: url
         value: https://github.com/redhat-appstudio/release-service-catalog.git
       - name: revision
-        value: development
+        value: staging
       - name: pathInRepo
         value: pipelines/rhtap-service-push/rhtap-service-push.yaml


### PR DESCRIPTION
This commit updates the default parameter of taskGitRevision in the staging branch pipelines to be staging instead of development.